### PR TITLE
Added global event handler framework for issue 76

### DIFF
--- a/__tests__/events-api.ts
+++ b/__tests__/events-api.ts
@@ -1,0 +1,118 @@
+import {
+  useTask,
+  addEventHandler,
+  removeEventHandler,
+} from "../src/index";
+import { EventTargetOptions } from "../src/types/index";
+import { mockSetup } from "../test-utils/components";
+
+describe("public events api", () => {
+  test("using events api outside of a component", async () => {
+    let fired = false;
+    const handler = () => {
+      fired = true;
+    };
+
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
+
+    addEventHandler(eventHandler);
+
+    await mockSetup(() => {
+      const task = useTask(function* () {
+        throw "err";
+      });
+      task.perform();
+    });
+
+    expect(fired).toBe(true);
+  });
+
+  test("using events api inside a component", async () => {
+    let fired = false;
+    await mockSetup(() => {
+      const handler = () => {
+        fired = true;
+      };
+
+      const eventHandler = {
+        target: EventTargetOptions.OnError,
+        key: "test",
+        handler,
+      };
+
+      addEventHandler(eventHandler);
+    });
+
+    await mockSetup(() => {
+      const task = useTask(function* () {
+        throw "err";
+      });
+      task.perform();
+    });
+
+    expect(fired).toBe(true);
+  });
+
+  it("fires only once with repeatedly adding same handler", async () => {
+    let fired = 0;
+    const handler = () => {
+      fired++;
+    };
+
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
+
+    addEventHandler(eventHandler);
+    addEventHandler(eventHandler);
+    addEventHandler(eventHandler);
+
+    await mockSetup(() => {
+      const task = useTask(function* () {
+        throw "err";
+      });
+      task.perform();
+    });
+
+    expect(fired).toBe(1);
+  });
+
+  test("clearing a handler from another component", async () => {
+    let fired = false;
+    await mockSetup(() => {
+      const handler = () => {
+        fired = true;
+      };
+
+      const eventHandler = {
+        target: EventTargetOptions.OnError,
+        key: "test",
+        handler,
+      };
+
+      addEventHandler(eventHandler);
+    });
+
+    await mockSetup(() => {
+      removeEventHandler({
+        target: EventTargetOptions.OnError,
+        key: "test",
+      });
+    });
+
+    await mockSetup(() => {
+      const task = useTask(function* () {
+        throw "err";
+      });
+      task.perform();
+    });
+
+    expect(fired).toBe(false);
+  });
+});

--- a/__tests__/events-api.ts
+++ b/__tests__/events-api.ts
@@ -1,8 +1,4 @@
-import {
-  useTask,
-  addEventHandler,
-  removeEventHandler,
-} from "../src/index";
+import { useTask, addEventHandler, removeEventHandler } from "../src/index";
 import { EventTargetOptions } from "../src/types/index";
 import { mockSetup } from "../test-utils/components";
 

--- a/__tests__/events.ts
+++ b/__tests__/events.ts
@@ -1,4 +1,4 @@
-import globalEvents  from "../src/utils/events";
+import {addEventHandler, hasEventHandler, removeEventHandler, clearTargetEventHandlers, fireEvent}  from "../src/utils/events";
 import { EventTargetOptions } from "../src/types/events"
 import useTask, { Task } from "../src/Task";
 import { mockSetup } from "../test-utils/components";
@@ -8,7 +8,6 @@ import { TaskInstance } from "../src/TaskInstance";
 describe("events", () => {
     it("adds event handler", async () => {
       const handler = () => {}
-      const {addEventHandler, hasEventHandler} = globalEvents();
       const eventHandler = {
         target: EventTargetOptions.OnError,
         key: "test",
@@ -22,7 +21,6 @@ describe("events", () => {
     
     it("removes event handler", async () => {
       const handler = () => {}
-      const {addEventHandler, hasEventHandler, removeEventHandler} = globalEvents();
       const eventHandler = {
         target: EventTargetOptions.OnError,
         key: "test",
@@ -48,7 +46,6 @@ describe("events", () => {
         key: "test",
         handler
       };    
-      const {addEventHandler, fireEvent, removeEventHandler} = globalEvents();
   
       await mockSetup(() => {
         const task = useTask(function*() {});
@@ -68,7 +65,6 @@ describe("events", () => {
     
     it("clears event handler", async () => {
       const handler = () => {}
-      const {addEventHandler, hasEventHandler, clearTargetEventHandlers} = globalEvents();
       const eventHandler = {
         target: EventTargetOptions.OnError,
         key: "test",
@@ -94,7 +90,6 @@ describe("events", () => {
         key: "test",
         handler
       };    
-      const {addEventHandler, fireEvent, clearTargetEventHandlers} = globalEvents();
   
       await mockSetup(() => {
         const task = useTask(function*() {});
@@ -124,7 +119,6 @@ describe("events", () => {
       key: "test",
       handler
     };    
-    const {addEventHandler, fireEvent} = globalEvents();
 
     await mockSetup(() => {
       const task = useTask(function*() {});
@@ -153,7 +147,6 @@ describe("events", () => {
       key: "test",
       handler
     };    
-    const {addEventHandler} = globalEvents();
 
     addEventHandler(eventHandler);
 

--- a/__tests__/events.ts
+++ b/__tests__/events.ts
@@ -6,7 +6,7 @@ import {
   fireEvent,
 } from "../src/utils/events";
 import { EventTargetOptions } from "../src/types/events";
-import useTask, { Task } from "../src/Task";
+import useTask from "../src/Task";
 import { mockSetup } from "../test-utils/components";
 import { TaskInstance } from "../src/TaskInstance";
 

--- a/__tests__/events.ts
+++ b/__tests__/events.ts
@@ -1,0 +1,51 @@
+import globalEvents, {EventTarget} from "../src/utils/events";
+import useTask, { Task } from "../src/Task";
+import { wait } from "./task-cancel";
+import { mockSetup } from "../test-utils/components";
+import { TaskInstance } from "../src/TaskInstance";
+
+
+describe("events", () => {
+    it("adds event handler", async () => {
+      const handler = () => {}
+      const {addEvent, hasEvent} = globalEvents();
+      const eventHandler = {
+        target: EventTarget.OnError,
+        key: "test",
+        handler
+      };
+  
+      addEvent(eventHandler);
+  
+      expect(hasEvent(eventHandler)).toBe(true);
+    });
+
+  it("adds & fires event handler", async () => {
+    let fired = false;
+    let taskInstance: null | TaskInstance<any> = null;
+    
+    const handler = () => {
+        fired = true;
+    };
+    const eventHandler = {
+      target: EventTarget.OnError,
+      key: "test",
+      handler
+    };    
+    const {addEvent, fireEvent} = globalEvents();
+
+    await mockSetup(() => {
+      const task = useTask(function*() {});
+      taskInstance = task.perform();
+    });
+    expect(taskInstance).not.toBe(null);
+
+    addEvent(eventHandler);
+
+    fireEvent({target: EventTarget.OnError, eventArgs: {
+        sender: taskInstance!
+    }})
+
+    expect(fired).toBe(true);
+  });
+});

--- a/__tests__/events.ts
+++ b/__tests__/events.ts
@@ -8,32 +8,32 @@ import { TaskInstance } from "../src/TaskInstance";
 describe("events", () => {
     it("adds event handler", async () => {
       const handler = () => {}
-      const {addEvent, hasEvent} = globalEvents();
+      const {addEventHandler, hasEventHandler} = globalEvents();
       const eventHandler = {
         target: EventTargetOptions.OnError,
         key: "test",
         handler
       };
   
-      addEvent(eventHandler);
+      addEventHandler(eventHandler);
   
-      expect(hasEvent(eventHandler)).toBe(true);
+      expect(hasEventHandler(eventHandler)).toBe(true);
     });
     
     it("removes event handler", async () => {
       const handler = () => {}
-      const {addEvent, hasEvent, removeEvent} = globalEvents();
+      const {addEventHandler, hasEventHandler, removeEventHandler} = globalEvents();
       const eventHandler = {
         target: EventTargetOptions.OnError,
         key: "test",
         handler
       };
   
-      addEvent(eventHandler);
+      addEventHandler(eventHandler);
 
-      removeEvent(eventHandler);
+      removeEventHandler(eventHandler);
   
-      expect(hasEvent(eventHandler)).toBe(false);
+      expect(hasEventHandler(eventHandler)).toBe(false);
     });
 
     test("removed event doesn't fire", async () => {
@@ -48,7 +48,7 @@ describe("events", () => {
         key: "test",
         handler
       };    
-      const {addEvent, fireEvent, removeEvent} = globalEvents();
+      const {addEventHandler, fireEvent, removeEventHandler} = globalEvents();
   
       await mockSetup(() => {
         const task = useTask(function*() {});
@@ -56,8 +56,8 @@ describe("events", () => {
       });
       expect(taskInstance).not.toBe(null);
   
-      addEvent(eventHandler);
-      removeEvent(eventHandler);
+      addEventHandler(eventHandler);
+      removeEventHandler(eventHandler);
   
       fireEvent({target: EventTargetOptions.OnError, eventArgs: {
           sender: taskInstance!
@@ -68,18 +68,18 @@ describe("events", () => {
     
     it("clears event handler", async () => {
       const handler = () => {}
-      const {addEvent, hasEvent, clearTargetEvents} = globalEvents();
+      const {addEventHandler, hasEventHandler, clearTargetEventHandlers} = globalEvents();
       const eventHandler = {
         target: EventTargetOptions.OnError,
         key: "test",
         handler
       };
   
-      addEvent(eventHandler);
+      addEventHandler(eventHandler);
 
-      clearTargetEvents(eventHandler);
+      clearTargetEventHandlers(eventHandler);
   
-      expect(hasEvent(eventHandler)).toBe(false);
+      expect(hasEventHandler(eventHandler)).toBe(false);
     });
 
     test("cleared event doesn't fire", async () => {
@@ -94,7 +94,7 @@ describe("events", () => {
         key: "test",
         handler
       };    
-      const {addEvent, fireEvent, clearTargetEvents} = globalEvents();
+      const {addEventHandler, fireEvent, clearTargetEventHandlers} = globalEvents();
   
       await mockSetup(() => {
         const task = useTask(function*() {});
@@ -102,8 +102,8 @@ describe("events", () => {
       });
       expect(taskInstance).not.toBe(null);
   
-      addEvent(eventHandler);
-      clearTargetEvents(eventHandler);
+      addEventHandler(eventHandler);
+      clearTargetEventHandlers(eventHandler);
   
       fireEvent({target: EventTargetOptions.OnError, eventArgs: {
           sender: taskInstance!
@@ -124,7 +124,7 @@ describe("events", () => {
       key: "test",
       handler
     };    
-    const {addEvent, fireEvent} = globalEvents();
+    const {addEventHandler, fireEvent} = globalEvents();
 
     await mockSetup(() => {
       const task = useTask(function*() {});
@@ -132,7 +132,7 @@ describe("events", () => {
     });
     expect(taskInstance).not.toBe(null);
 
-    addEvent(eventHandler);
+    addEventHandler(eventHandler);
 
     fireEvent({target: EventTargetOptions.OnError, eventArgs: {
         sender: taskInstance!
@@ -153,9 +153,9 @@ describe("events", () => {
       key: "test",
       handler
     };    
-    const {addEvent} = globalEvents();
+    const {addEventHandler} = globalEvents();
 
-    addEvent(eventHandler);
+    addEventHandler(eventHandler);
 
     await mockSetup(() => {
       const task = useTask(function*() { throw "err"; });

--- a/__tests__/events.ts
+++ b/__tests__/events.ts
@@ -1,136 +1,150 @@
-import {addEventHandler, hasEventHandler, removeEventHandler, clearTargetEventHandlers, fireEvent}  from "../src/utils/events";
-import { EventTargetOptions } from "../src/types/events"
+import {
+  addEventHandler,
+  hasEventHandler,
+  removeEventHandler,
+  clearTargetEventHandlers,
+  fireEvent,
+} from "../src/utils/events";
+import { EventTargetOptions } from "../src/types/events";
 import useTask, { Task } from "../src/Task";
 import { mockSetup } from "../test-utils/components";
 import { TaskInstance } from "../src/TaskInstance";
 
-
 describe("events", () => {
-    it("adds event handler", async () => {
-      const handler = () => {}
-      const eventHandler = {
-        target: EventTargetOptions.OnError,
-        key: "test",
-        handler
-      };
-  
-      addEventHandler(eventHandler);
-  
-      expect(hasEventHandler(eventHandler)).toBe(true);
-    });
-    
-    it("removes event handler", async () => {
-      const handler = () => {}
-      const eventHandler = {
-        target: EventTargetOptions.OnError,
-        key: "test",
-        handler
-      };
-  
-      addEventHandler(eventHandler);
+  it("adds event handler", async () => {
+    const handler = () => {};
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
 
-      removeEventHandler(eventHandler);
-  
-      expect(hasEventHandler(eventHandler)).toBe(false);
-    });
+    addEventHandler(eventHandler);
 
-    test("removed event doesn't fire", async () => {
-      let fired = false;
-      let taskInstance: null | TaskInstance<any> = null;
-      
-      const handler = () => {
-          fired = true;
-      };
-      const eventHandler = {
-        target: EventTargetOptions.OnError,
-        key: "test",
-        handler
-      };    
-  
-      await mockSetup(() => {
-        const task = useTask(function*() {});
-        taskInstance = task.perform();
-      });
-      expect(taskInstance).not.toBe(null);
-  
-      addEventHandler(eventHandler);
-      removeEventHandler(eventHandler);
-  
-      fireEvent({target: EventTargetOptions.OnError, eventArgs: {
-          sender: taskInstance!
-      }})
-  
-      expect(fired).toBe(false);
-    });
-    
-    it("clears event handler", async () => {
-      const handler = () => {}
-      const eventHandler = {
-        target: EventTargetOptions.OnError,
-        key: "test",
-        handler
-      };
-  
-      addEventHandler(eventHandler);
+    expect(hasEventHandler(eventHandler)).toBe(true);
+  });
 
-      clearTargetEventHandlers(eventHandler);
-  
-      expect(hasEventHandler(eventHandler)).toBe(false);
-    });
+  it("removes event handler", async () => {
+    const handler = () => {};
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
 
-    test("cleared event doesn't fire", async () => {
-      let fired = false;
-      let taskInstance: null | TaskInstance<any> = null;
-      
-      const handler = () => {
-          fired = true;
-      };
-      const eventHandler = {
-        target: EventTargetOptions.OnError,
-        key: "test",
-        handler
-      };    
-  
-      await mockSetup(() => {
-        const task = useTask(function*() {});
-        taskInstance = task.perform();
-      });
-      expect(taskInstance).not.toBe(null);
-  
-      addEventHandler(eventHandler);
-      clearTargetEventHandlers(eventHandler);
-  
-      fireEvent({target: EventTargetOptions.OnError, eventArgs: {
-          sender: taskInstance!
-      }})
-  
-      expect(fired).toBe(false);
-    });
+    addEventHandler(eventHandler);
 
-  it("adds & fires event handler", async () => {
+    removeEventHandler(eventHandler);
+
+    expect(hasEventHandler(eventHandler)).toBe(false);
+  });
+
+  test("removed event doesn't fire", async () => {
     let fired = false;
     let taskInstance: null | TaskInstance<any> = null;
-    
+
     const handler = () => {
-        fired = true;
+      fired = true;
     };
     const eventHandler = {
       target: EventTargetOptions.OnError,
       key: "test",
-      handler
-    };    
+      handler,
+    };
 
     await mockSetup(() => {
-      const task = useTask(function*() {});
+      const task = useTask(function* () {});
+      taskInstance = task.perform();
+    });
+    expect(taskInstance).not.toBe(null);
+
+    addEventHandler(eventHandler);
+    removeEventHandler(eventHandler);
+
+    fireEvent({
+      target: EventTargetOptions.OnError,
+      eventArgs: {
+        sender: taskInstance!,
+      },
+    });
+
+    expect(fired).toBe(false);
+  });
+
+  it("clears event handler", async () => {
+    const handler = () => {};
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
+
+    addEventHandler(eventHandler);
+
+    clearTargetEventHandlers(eventHandler);
+
+    expect(hasEventHandler(eventHandler)).toBe(false);
+  });
+
+  test("cleared event doesn't fire", async () => {
+    let fired = false;
+    let taskInstance: null | TaskInstance<any> = null;
+
+    const handler = () => {
+      fired = true;
+    };
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
+
+    await mockSetup(() => {
+      const task = useTask(function* () {});
+      taskInstance = task.perform();
+    });
+    expect(taskInstance).not.toBe(null);
+
+    addEventHandler(eventHandler);
+    clearTargetEventHandlers(eventHandler);
+
+    fireEvent({
+      target: EventTargetOptions.OnError,
+      eventArgs: {
+        sender: taskInstance!,
+      },
+    });
+
+    expect(fired).toBe(false);
+  });
+
+  it("adds & fires event handler", async () => {
+    let fired = false;
+    let taskInstance: null | TaskInstance<any> = null;
+
+    const handler = () => {
+      fired = true;
+    };
+    const eventHandler = {
+      target: EventTargetOptions.OnError,
+      key: "test",
+      handler,
+    };
+
+    await mockSetup(() => {
+      const task = useTask(function* () {});
       taskInstance = task.perform();
     });
     expect(taskInstance).not.toBe(null);
 
     addEventHandler(eventHandler);
 
-    fireEvent({target: EventTargetOptions.OnError, eventArgs: {
-        sender: taskInstance!
-    }})
+    fireEvent({
+      target: EventTargetOptions.OnError,
+      eventArgs: {
+        sender: taskInstance!,
+      },
+    });
 
     expect(fired).toBe(true);
   });
@@ -138,20 +152,22 @@ describe("events", () => {
   test("error event handler fires", async () => {
     let fired = false;
     let taskInstance: null | TaskInstance<any> = null;
-    
+
     const handler = () => {
-        fired = true;
+      fired = true;
     };
     const eventHandler = {
       target: EventTargetOptions.OnError,
       key: "test",
-      handler
-    };    
+      handler,
+    };
 
     addEventHandler(eventHandler);
 
     await mockSetup(() => {
-      const task = useTask(function*() { throw "err"; });
+      const task = useTask(function* () {
+        throw "err";
+      });
       taskInstance = task.perform();
     });
 

--- a/src/TaskInstance.ts
+++ b/src/TaskInstance.ts
@@ -8,6 +8,7 @@ import {
   onFulfilled,
   onRejected,
 } from "./types/index";
+import globalEvents, {EventTarget} from "./utils/events";
 
 export type TaskInstanceStatus =
   | "running"
@@ -190,6 +191,7 @@ function runTaskInstance<T>(
   // because not all environemnts support package.exports field (TS, WP4 and others), it's necessary to look for CAF function in two places
   const token = new cancelToken();
   const cancelable = CAF(cb, token);
+  const {fireEvent} = globalEvents();
   taskInstance.token = token;
 
   taskInstance.hasStarted = true;
@@ -215,6 +217,11 @@ function runTaskInstance<T>(
     .catch((e) => {
       if (e !== "cancel") {
         taskInstance.error = e;
+        fireEvent({target: EventTarget.OnError, eventArgs: {
+          sender: taskInstance,
+          params,
+          error: e
+        }})
       }
 
       setFinished();

--- a/src/TaskInstance.ts
+++ b/src/TaskInstance.ts
@@ -8,7 +8,7 @@ import {
   onFulfilled,
   onRejected,
 } from "./types/index";
-import globalEvents from "./utils/events";
+import {fireEvent} from "./utils/events";
 import {EventTargetOptions} from "./types/events"
 
 export type TaskInstanceStatus =
@@ -192,7 +192,6 @@ function runTaskInstance<T>(
   // because not all environemnts support package.exports field (TS, WP4 and others), it's necessary to look for CAF function in two places
   const token = new cancelToken();
   const cancelable = CAF(cb, token);
-  const {fireEvent} = globalEvents();
   taskInstance.token = token;
 
   taskInstance.hasStarted = true;

--- a/src/TaskInstance.ts
+++ b/src/TaskInstance.ts
@@ -9,7 +9,7 @@ import {
   onRejected,
 } from "./types/index";
 import {fireEvent} from "./utils/events";
-import {EventTargetOptions} from "./types/events"
+import {EventTargetOptions} from "./types/index"
 
 export type TaskInstanceStatus =
   | "running"

--- a/src/TaskInstance.ts
+++ b/src/TaskInstance.ts
@@ -8,7 +8,8 @@ import {
   onFulfilled,
   onRejected,
 } from "./types/index";
-import globalEvents, {EventTarget} from "./utils/events";
+import globalEvents from "./utils/events";
+import {EventTargetOptions} from "./types/events"
 
 export type TaskInstanceStatus =
   | "running"
@@ -217,7 +218,7 @@ function runTaskInstance<T>(
     .catch((e) => {
       if (e !== "cancel") {
         taskInstance.error = e;
-        fireEvent({target: EventTarget.OnError, eventArgs: {
+        fireEvent({target: EventTargetOptions.OnError, eventArgs: {
           sender: taskInstance,
           params,
           error: e

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export { default as useTaskGroup, TaskGroup } from "./TaskGroup";
 export { default as useTask, Task } from "./Task";
 export { TaskInstance } from "./TaskInstance";
 export { YieldReturn } from './types';
+
+export { addEventHandler, removeEventHandler } from "./utils/events"

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,37 +1,43 @@
-
 import { TaskInstance } from "../TaskInstance";
 
 export const EventTargetOptions = {
-    OnError: "onError",
+  OnError: "onError",
 } as const;
 
-export type EventTarget = typeof EventTargetOptions[keyof typeof EventTargetOptions];
+export type EventTarget =
+  typeof EventTargetOptions[keyof typeof EventTargetOptions];
 
 export type EventArgs = {
-    sender: TaskInstance<any>,
-    params?: any[],
-    error?: unknown,
-    data?: unknown
-}
+  sender: TaskInstance<any>;
+  params?: any[];
+  error?: unknown;
+  data?: unknown;
+};
 
 export type Events = {
-    [key in EventTarget]: Record<string, ((eventArgs: EventArgs) => PromiseLike<void> | void | Promise<void>) | undefined>;
+  [key in EventTarget]: Record<
+    string,
+    | ((eventArgs: EventArgs) => PromiseLike<void> | void | Promise<void>)
+    | undefined
+  >;
 };
 
 export type ClearEventParams = {
-    target: EventTarget,
-}
+  target: EventTarget;
+};
 
 export type FireEventParams = ClearEventParams & {
-    eventArgs: EventArgs
-}
+  eventArgs: EventArgs;
+};
 
 export type RemoveEventParams = ClearEventParams & {
-    key: string,
-}
+  key: string;
+};
 
 export type HasEventParams = RemoveEventParams;
 
 export type AddEventParams = RemoveEventParams & {
-    handler: (...eventArgs: unknown[]) => PromiseLike<void> | void | Promise<void>
-}
+  handler: (
+    ...eventArgs: unknown[]
+  ) => PromiseLike<void> | void | Promise<void>;
+};

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -22,21 +22,21 @@ export type Events = {
   >;
 };
 
-export type ClearEventParams = {
+export type ClearEventHandlerParams = {
   target: EventTarget;
 };
 
-export type FireEventParams = ClearEventParams & {
+export type FireEventHandlerParams = ClearEventHandlerParams & {
   eventArgs: EventArgs;
 };
 
-export type RemoveEventParams = ClearEventParams & {
+export type RemoveEventHandlerParams = ClearEventHandlerParams & {
   key: string;
 };
 
-export type HasEventParams = RemoveEventParams;
+export type HasEventHandlerParams = RemoveEventHandlerParams;
 
-export type AddEventParams = RemoveEventParams & {
+export type AddEventHandlerParams = RemoveEventHandlerParams & {
   handler: (
     ...eventArgs: unknown[]
   ) => PromiseLike<void> | void | Promise<void>;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,35 @@
+
+import { TaskInstance } from "../TaskInstance";
+
+export const EventTargetOptions = {
+    OnError: "onError",
+} as const;
+
+export type EventTarget = typeof EventTargetOptions[keyof typeof EventTargetOptions];
+
+export interface IEventArgs {
+    sender: TaskInstance<any>,
+    params?: any[],
+    error?: unknown,
+    data?: unknown
+}
+
+export type Events = {
+    [key in EventTarget]: Record<string, ((eventArgs: IEventArgs) => PromiseLike<void> | void | Promise<void>) | undefined>;
+};
+
+export interface IClearEvents {
+    target: EventTarget,
+}
+
+export interface IFireEvent extends IClearEvents {
+    eventArgs: IEventArgs
+}
+
+export interface IRemoveEvent extends IClearEvents {
+    key: string,
+}
+
+export interface IAddEvent extends IRemoveEvent {
+    handler: (...eventArgs: unknown[]) => PromiseLike<void> | void | Promise<void>
+}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,7 +7,7 @@ export const EventTargetOptions = {
 
 export type EventTarget = typeof EventTargetOptions[keyof typeof EventTargetOptions];
 
-export interface IEventArgs {
+export type EventArgs = {
     sender: TaskInstance<any>,
     params?: any[],
     error?: unknown,
@@ -15,21 +15,23 @@ export interface IEventArgs {
 }
 
 export type Events = {
-    [key in EventTarget]: Record<string, ((eventArgs: IEventArgs) => PromiseLike<void> | void | Promise<void>) | undefined>;
+    [key in EventTarget]: Record<string, ((eventArgs: EventArgs) => PromiseLike<void> | void | Promise<void>) | undefined>;
 };
 
-export interface IClearEvents {
+export type ClearEventParams = {
     target: EventTarget,
 }
 
-export interface IFireEvent extends IClearEvents {
-    eventArgs: IEventArgs
+export type FireEventParams = ClearEventParams & {
+    eventArgs: EventArgs
 }
 
-export interface IRemoveEvent extends IClearEvents {
+export type RemoveEventParams = ClearEventParams & {
     key: string,
 }
 
-export interface IAddEvent extends IRemoveEvent {
+export type HasEventParams = RemoveEventParams;
+
+export type AddEventParams = RemoveEventParams & {
     handler: (...eventArgs: unknown[]) => PromiseLike<void> | void | Promise<void>
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,16 @@
 import { Task } from "../Task";
 
-export {EventArgs, EventTarget, EventTargetOptions, Events, AddEventParams, HasEventParams, FireEventParams, ClearEventParams, RemoveEventParams} from "./events";
+export {
+  EventArgs,
+  EventTarget,
+  EventTargetOptions,
+  Events,
+  AddEventHandlerParams,
+  HasEventHandlerParams,
+  FireEventHandlerParams,
+  ClearEventHandlerParams,
+  RemoveEventHandlerParams,
+} from "./events";
 
 export interface AbortSignalWithPromise extends AbortSignal {
   pr: Promise<void>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
 import { Task } from "../Task";
 
+export {EventArgs, EventTarget, EventTargetOptions, Events, AddEventParams, HasEventParams, FireEventParams, ClearEventParams, RemoveEventParams} from "./events";
+
 export interface AbortSignalWithPromise extends AbortSignal {
   pr: Promise<void>;
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,1 +1,1 @@
-export { ref, reactive, onMounted, onUnmounted, onBeforeUnmount, defineComponent, computed, Ref, watchEffect, watch, getCurrentInstance, effectScope, EffectScope, onServerPrefetch } from "vue";
+export { ref, readonly, reactive, onMounted, onUnmounted, onBeforeUnmount, defineComponent, computed, Ref, watchEffect, watch, getCurrentInstance, effectScope, EffectScope, onServerPrefetch } from "vue";

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,1 +1,1 @@
-export { ref, readonly, reactive, onMounted, onUnmounted, onBeforeUnmount, defineComponent, computed, Ref, watchEffect, watch, getCurrentInstance, effectScope, EffectScope, onServerPrefetch } from "vue";
+export { ref, reactive, onMounted, onUnmounted, onBeforeUnmount, defineComponent, computed, Ref, watchEffect, watch, getCurrentInstance, effectScope, EffectScope, onServerPrefetch } from "vue";

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -4,33 +4,24 @@ const events: Events = {
     onError: {},
 }
 
-export default function globalEvents() { 
-    const hasEventHandler = ({target, key}: HasEventParams) => {
-        return events[target][key] !== undefined;
-    }
 
-    const addEventHandler = ({target, key, handler}: AddEventParams) => {
-        events[target][key] = handler;
-    }
+export function hasEventHandler ({target, key}: HasEventParams) {
+    return events[target][key] !== undefined;
+}
 
-    const removeEventHandler = ({target, key}: RemoveEventParams) => {
-        events[target][key] = undefined;
-    }
+export function addEventHandler ({target, key, handler}: AddEventParams) {
+    events[target][key] = handler;
+}
 
-    const clearTargetEventHandlers = ({target}: ClearEventParams) => {
-        events[target] = {};
-    }
+export function removeEventHandler ({target, key}: RemoveEventParams) {
+    events[target][key] = undefined;
+}
 
-    const fireEvent = ({target, eventArgs}: FireEventParams) => {
-        const eventsToFire = Object.values(events[target]);
-        eventsToFire.filter(x => x !== undefined).forEach(x => x!(eventArgs))
-    }
+export function clearTargetEventHandlers ({target}: ClearEventParams) {
+    events[target] = {};
+}
 
-    return {
-        hasEventHandler,
-        addEventHandler,
-        removeEventHandler,
-        clearTargetEventHandlers,
-        fireEvent
-    }; 
+export function fireEvent ({target, eventArgs}: FireEventParams) {
+    const eventsToFire = Object.values(events[target]);
+    eventsToFire.filter(x => x !== undefined).forEach(x => x!(eventArgs))
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,27 +1,33 @@
-import {RemoveEventParams, Events, AddEventParams, FireEventParams, ClearEventParams, HasEventParams} from "../types/events"
+import {
+  RemoveEventParams,
+  Events,
+  AddEventParams,
+  FireEventParams,
+  ClearEventParams,
+  HasEventParams,
+} from "../types/events";
 
 const events: Events = {
-    onError: {},
+  onError: {},
+};
+
+export function hasEventHandler({ target, key }: HasEventParams) {
+  return events[target][key] !== undefined;
 }
 
-
-export function hasEventHandler ({target, key}: HasEventParams) {
-    return events[target][key] !== undefined;
+export function addEventHandler({ target, key, handler }: AddEventParams) {
+  events[target][key] = handler;
 }
 
-export function addEventHandler ({target, key, handler}: AddEventParams) {
-    events[target][key] = handler;
+export function removeEventHandler({ target, key }: RemoveEventParams) {
+  events[target][key] = undefined;
 }
 
-export function removeEventHandler ({target, key}: RemoveEventParams) {
-    events[target][key] = undefined;
+export function clearTargetEventHandlers({ target }: ClearEventParams) {
+  events[target] = {};
 }
 
-export function clearTargetEventHandlers ({target}: ClearEventParams) {
-    events[target] = {};
-}
-
-export function fireEvent ({target, eventArgs}: FireEventParams) {
-    const eventsToFire = Object.values(events[target]);
-    eventsToFire.filter(x => x !== undefined).forEach(x => x!(eventArgs))
+export function fireEvent({ target, eventArgs }: FireEventParams) {
+  const eventsToFire = Object.values(events[target]);
+  eventsToFire.filter((x) => x !== undefined).forEach((x) => x!(eventArgs));
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,37 +1,36 @@
-import {ref} from "./api";
-import {IRemoveEvent, Events, IAddEvent, IFireEvent} from "../types/events"
+import {RemoveEventParams, Events, AddEventParams, FireEventParams, ClearEventParams, HasEventParams} from "../types/events"
 
 const events: Events = {
     onError: {},
 }
 
 export default function globalEvents() { 
-    const hasEvent = ({target, key}: IRemoveEvent) => {
+    const hasEventHandler = ({target, key}: HasEventParams) => {
         return events[target][key] !== undefined;
     }
 
-    const addEvent = ({target, key, handler}: IAddEvent) => {
+    const addEventHandler = ({target, key, handler}: AddEventParams) => {
         events[target][key] = handler;
     }
 
-    const removeEvent = ({target, key}: IRemoveEvent) => {
+    const removeEventHandler = ({target, key}: RemoveEventParams) => {
         events[target][key] = undefined;
     }
 
-    const clearTargetEvents = ({target}: IRemoveEvent) => {
+    const clearTargetEventHandlers = ({target}: ClearEventParams) => {
         events[target] = {};
     }
 
-    const fireEvent = ({target, eventArgs}: IFireEvent) => {
+    const fireEvent = ({target, eventArgs}: FireEventParams) => {
         const eventsToFire = Object.values(events[target]);
         eventsToFire.filter(x => x !== undefined).forEach(x => x!(eventArgs))
     }
 
     return {
-        hasEvent,
-        addEvent,
-        removeEvent,
-        clearTargetEvents,
+        hasEventHandler,
+        addEventHandler,
+        removeEventHandler,
+        clearTargetEventHandlers,
         fireEvent
     }; 
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,68 @@
+import {ref, readonly} from "./api";
+import { TaskInstance } from "../TaskInstance";
+
+export enum EventTarget {
+    OnError = "onError",
+}
+
+export interface IEventArgs {
+    sender: TaskInstance<any>,
+    params?: any[],
+    error?: unknown,
+    data?: unknown
+}
+
+export type Events = {
+    [key in EventTarget]: Record<string, ((eventArgs: IEventArgs) => PromiseLike<void> | void | Promise<void>) | undefined>;
+};
+
+export interface IClearEvents {
+    target: EventTarget,
+}
+
+export interface IFireEvent extends IClearEvents {
+    eventArgs: IEventArgs
+}
+
+export interface IRemoveEvent extends IClearEvents {
+    key: string,
+}
+
+export interface IAddEvent extends IRemoveEvent {
+    handler: (...eventArgs: unknown[]) => PromiseLike<void> | void | Promise<void>
+}
+
+const events = ref<Events>({
+    onError: {},
+})
+
+export default function globalEvents() { 
+    const hasEvent = ({target, key}: IRemoveEvent) => {
+        return events.value[target][key] !== undefined;
+    }
+
+    const addEvent = ({target, key, handler}: IAddEvent) => {
+        events.value[target][key] = handler;
+    }
+
+    const removeEvent = ({target, key}: IRemoveEvent) => {
+        events.value[target][key] = undefined;
+    }
+
+    const clearTargetEvents = ({target}: IRemoveEvent) => {
+        events.value[target] = {};
+    }
+
+    const fireEvent = ({target, eventArgs}: IFireEvent) => {
+        const eventsToFire = Object.values(events.value[target]);
+        eventsToFire.filter(x => x !== undefined).forEach(x => x!(eventArgs))
+    }
+
+    return {
+        hasEvent,
+        addEvent,
+        removeEvent,
+        clearTargetEvents,
+        fireEvent
+    }; 
+}

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,36 +1,5 @@
-import {ref, readonly} from "./api";
-import { TaskInstance } from "../TaskInstance";
-
-export enum EventTarget {
-    OnError = "onError",
-}
-
-export interface IEventArgs {
-    sender: TaskInstance<any>,
-    params?: any[],
-    error?: unknown,
-    data?: unknown
-}
-
-export type Events = {
-    [key in EventTarget]: Record<string, ((eventArgs: IEventArgs) => PromiseLike<void> | void | Promise<void>) | undefined>;
-};
-
-export interface IClearEvents {
-    target: EventTarget,
-}
-
-export interface IFireEvent extends IClearEvents {
-    eventArgs: IEventArgs
-}
-
-export interface IRemoveEvent extends IClearEvents {
-    key: string,
-}
-
-export interface IAddEvent extends IRemoveEvent {
-    handler: (...eventArgs: unknown[]) => PromiseLike<void> | void | Promise<void>
-}
+import {ref} from "./api";
+import {IRemoveEvent, Events, IAddEvent, IFireEvent} from "../types/events"
 
 const events = ref<Events>({
     onError: {},

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,33 +1,37 @@
 import {
-  RemoveEventParams,
+  RemoveEventHandlerParams,
   Events,
-  AddEventParams,
-  FireEventParams,
-  ClearEventParams,
-  HasEventParams,
+  AddEventHandlerParams,
+  FireEventHandlerParams,
+  ClearEventHandlerParams,
+  HasEventHandlerParams,
 } from "../types/events";
 
 const events: Events = {
   onError: {},
 };
 
-export function hasEventHandler({ target, key }: HasEventParams) {
+export function hasEventHandler({ target, key }: HasEventHandlerParams) {
   return events[target][key] !== undefined;
 }
 
-export function addEventHandler({ target, key, handler }: AddEventParams) {
+export function addEventHandler({
+  target,
+  key,
+  handler,
+}: AddEventHandlerParams) {
   events[target][key] = handler;
 }
 
-export function removeEventHandler({ target, key }: RemoveEventParams) {
+export function removeEventHandler({ target, key }: RemoveEventHandlerParams) {
   events[target][key] = undefined;
 }
 
-export function clearTargetEventHandlers({ target }: ClearEventParams) {
+export function clearTargetEventHandlers({ target }: ClearEventHandlerParams) {
   events[target] = {};
 }
 
-export function fireEvent({ target, eventArgs }: FireEventParams) {
+export function fireEvent({ target, eventArgs }: FireEventHandlerParams) {
   const eventsToFire = Object.values(events[target]);
   eventsToFire.filter((x) => x !== undefined).forEach((x) => x!(eventArgs));
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,29 +1,29 @@
 import {ref} from "./api";
 import {IRemoveEvent, Events, IAddEvent, IFireEvent} from "../types/events"
 
-const events = ref<Events>({
+const events: Events = {
     onError: {},
-})
+}
 
 export default function globalEvents() { 
     const hasEvent = ({target, key}: IRemoveEvent) => {
-        return events.value[target][key] !== undefined;
+        return events[target][key] !== undefined;
     }
 
     const addEvent = ({target, key, handler}: IAddEvent) => {
-        events.value[target][key] = handler;
+        events[target][key] = handler;
     }
 
     const removeEvent = ({target, key}: IRemoveEvent) => {
-        events.value[target][key] = undefined;
+        events[target][key] = undefined;
     }
 
     const clearTargetEvents = ({target}: IRemoveEvent) => {
-        events.value[target] = {};
+        events[target] = {};
     }
 
     const fireEvent = ({target, eventArgs}: IFireEvent) => {
-        const eventsToFire = Object.values(events.value[target]);
+        const eventsToFire = Object.values(events[target]);
         eventsToFire.filter(x => x !== undefined).forEach(x => x!(eventArgs))
     }
 


### PR DESCRIPTION
Issue #76 requested a global event handler for errors. 

In this pull request I have set up the framework for a global event handler store and testing for such a store. I didn't want to go too much further than this before presenting it for review/comments.

I deliberately made it extensible to add for other global event hooks but currently it is only set up for `OnError`

It works by making a light global store of event handlers and only exposes that store through a set of controlled functions.

Note: I wrote this while on the road. Couldn't give it the sort of thorough check that I'd normally prefer.