### PR TITLE
docs: Add link to GitHub

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     nav: [
       { text: "Home", link: "/" },
       { text: "Guide", link: "/introduction/" },
+      { text: "GitHub", link: "https://github.com/MartinMalinda/vue-concurrency/" },
     ],
     sidebar: {
       '/': [


### PR DESCRIPTION
Hey! 👋 
I couldn't find a GitHub link in the documentation. Just a friendly thought, it would be great to add it.